### PR TITLE
Modify php-test-stepup Dockerfile

### DIFF
--- a/docker/php-test-stepup/Dockerfile
+++ b/docker/php-test-stepup/Dockerfile
@@ -1,5 +1,7 @@
 FROM php:7.2
 
+SHELL ["/bin/bash", "-c"]
+
 ARG NPM_UID=1000
 ARG NPM_GID=1000
 
@@ -19,14 +21,18 @@ RUN apt-get update && apt-get install -y \
 ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION 10
 
-# Install nvm with node and npm
+# Install nvm
+# For reference look at: https://github.com/creationix/nvm#install-script
+RUN mkdir -p /usr/local/nvm
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | bash
-    && source $NVM_DIR/nvm.sh \
+
+# Install node and npm
+RUN source $NVM_DIR/nvm.sh \
     && nvm install $NODE_VERSION \
     && nvm alias default $NODE_VERSION \
     && nvm use default
 
-    # Composer
+# Composer
 COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
 
 # Fix npm


### PR DESCRIPTION
Added \ because of a parse error.
Changed standard shell to bash instead of sh.
Before the change the script would complain about the NVM_DIR not
existing, so before the NVM install the script will create the usr/local/nvm directory.