### PR TITLE
Add Xdebug to the test container and bump PHP version

### DIFF
--- a/docker/php-test-stepup/Dockerfile
+++ b/docker/php-test-stepup/Dockerfile
@@ -21,11 +21,19 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-configure gmp \
     && docker-php-ext-install gmp \
     && docker-php-ext-install pdo_mysql exif gd \
+    ## Xdebug
+    && pecl install xdebug \
     ## APCu
     && pecl install apcu \
     && pecl install apcu_bc-1.0.3 \
     && docker-php-ext-enable apcu --ini-name 10-docker-php-ext-apcu.ini \
     && docker-php-ext-enable apc --ini-name 20-docker-php-ext-apc.ini
+
+RUN docker-php-ext-enable xdebug
+RUN echo "xdebug.remote_enable=1" >> /usr/local/etc/php/php.ini
+
+# Xdebug init
+COPY ./conf/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
 ENV NVM_DIR /usr/local/nvm
 ENV NODE_VERSION 14
@@ -48,6 +56,7 @@ COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
 # Fix npm
 RUN mkdir /.npm && chown -R "${NPM_UID}:${NPM_GID}" "/.npm"
 RUN mkdir /.config && chown -R "${NPM_UID}:${NPM_GID}" "/.config"
+
 
 # Cleanup
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/docker/php-test-stepup/Dockerfile
+++ b/docker/php-test-stepup/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2
+FROM php:7.3
 
 SHELL ["/bin/bash", "-c"]
 

--- a/docker/php-test-stepup/conf/xdebug.ini
+++ b/docker/php-test-stepup/conf/xdebug.ini
@@ -1,0 +1,4 @@
+xdebug.mode = debug
+xdebug.discover_client_host = true
+xdebug.idekey = PHPSTORM
+zend_extension=xdebug


### PR DESCRIPTION
Xdebug 3 is needed to run tests with phpunit.
PHP bumped from 7.2 to 7.3 This was needed for the package Mockery.