### PR TITLE
Install pinned xdebug version

### DIFF
--- a/docker/php-build-eb/Dockerfile
+++ b/docker/php-build-eb/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
     libpng-dev \
     && docker-php-ext-install pdo_mysql exif gd \
     ## APCu
-    && pecl install xdebug \
+    && pecl install xdebug-3.1.6 \
     && pecl install apcu \
     && pecl install apcu_bc-1.0.3 \
     && docker-php-ext-enable apcu --ini-name 10-docker-php-ext-apcu.ini \

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -11,7 +11,7 @@ COPY --from=composer:1 /usr/bin/composer /usr/bin/composer
 COPY ./conf/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 RUN apk --update --no-cache add git npm yarn autoconf g++ make && \
     docker-php-ext-install exif && \
-    pecl install -f xdebug && \
+    pecl install -f xdebug-3.1.6 && \
     docker-php-ext-enable xdebug && \
     apk del --purge autoconf g++ make
 CMD ["/usr/local/sbin/php-fpm" , "-F"]

--- a/docker/php-test-stepup/Dockerfile
+++ b/docker/php-test-stepup/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-install gmp \
     && docker-php-ext-install pdo_mysql exif gd \
     ## Xdebug
-    && pecl install xdebug \
+    && pecl install xdebug-3.1.6 \
     ## APCu
     && pecl install apcu \
     && pecl install apcu_bc-1.0.3 \


### PR DESCRIPTION
The pecl install command installed the latest version. Since xdebug 3.2 only php 8 and higher is supported