### PR TITLE
Use latest version of Composer

### DIFF
--- a/docker/php-build-eb/Dockerfile
+++ b/docker/php-build-eb/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
     && docker-php-ext-enable apc --ini-name 20-docker-php-ext-apc.ini
 
 # Composer
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
 # Fix npm
 RUN mkdir /.npm && chown -R "${NPM_UID}:${NPM_GID}" "/.npm"

--- a/docker/php-build-stepup/Dockerfile
+++ b/docker/php-build-stepup/Dockerfile
@@ -27,7 +27,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.37.2/install.sh | b
     && nvm use default
 
     # Composer
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
 # Fix npm
 RUN mkdir /.npm && chown -R "${NPM_UID}:${NPM_GID}" "/.npm"

--- a/docker/php-fpm/Dockerfile
+++ b/docker/php-fpm/Dockerfile
@@ -7,7 +7,7 @@ COPY ./conf/10-docker-opcache-openconext.conf /usr/local/etc/php/conf.d/
 CMD ["/usr/local/sbin/php-fpm" , "-F"]
 
 FROM fpmprod AS fpmdev
-COPY --from=composer:1 /usr/bin/composer /usr/bin/composer
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 COPY ./conf/xdebug.ini /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 RUN apk --update --no-cache add git npm yarn autoconf g++ make && \
     docker-php-ext-install exif && \

--- a/docker/php-test-stepup/Dockerfile
+++ b/docker/php-test-stepup/Dockerfile
@@ -56,7 +56,7 @@ RUN source $NVM_DIR/nvm.sh \
     && npm install -g yarn
 
 # Composer
-COPY --from=composer:1 /usr/bin/composer /usr/local/bin/composer
+COPY --from=composer /usr/bin/composer /usr/local/bin/composer
 
 # Fix npm
 RUN mkdir /.npm && chown -R "${NPM_UID}:${NPM_GID}" "/.npm"


### PR DESCRIPTION
The version pin on version 1 of composer is removed from the base images. As this version is no longer maintained, and it restricts use of the Composer Audit feature.